### PR TITLE
Update Sonar Scanner to 6.1.0.447

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 env:
-  SONAR_SCANNER_VERSION: 4.7.0.2747
+  SONAR_SCANNER_VERSION: 6.1.0.4477
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   PARALLEL_THREADS: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ RUN apt-get update && apt-get install --yes \
     check \
     clang-format-13 \
     libserialport-dev \
-    ros-humble-gps-msgs
+    ros-humble-gps-msgs \
+    # Sonar-scanner dependency
+    openjdk-19-jdk
 
 # Add a "dockerdev" user with sudo capabilities
 # 1000 is the first user ID issued on Ubuntu; might

--- a/code_coverage.sh
+++ b/code_coverage.sh
@@ -11,6 +11,8 @@
 
 export GITHUB_TOKEN=$1
 export SONAR_TOKEN=$2
+export JAVA_HOME=/usr/lib/jvm/java-19-openjdk-amd64
+export PATH=$JAVA_HOME/bin:$PATH
 
 mkdir -p build
 cd build

--- a/code_coverage.sh
+++ b/code_coverage.sh
@@ -11,8 +11,6 @@
 
 export GITHUB_TOKEN=$1
 export SONAR_TOKEN=$2
-export JAVA_HOME=/usr/lib/jvm/java-19-openjdk-amd64
-export PATH=$JAVA_HOME/bin:$PATH
 
 mkdir -p build
 cd build


### PR DESCRIPTION
The Sonar Scanner we are using is out of date.
We see the following error when CI runs:
`java.lang.UnsupportedClassVersionError: org/sonar/batch/bootstrapper/EnvironmentInformation has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0`
The sonar scanner we download contains its own JRE which is on version 11/55. 
